### PR TITLE
Portfolio: preserve data in the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # My-Portfolio
 
-> Portfolio  window popup.
+> Portfolio  local storage.
 
 ![setup m-version skeleton](./photos/shots/screenshot1.png)
 ![portfolio mobile version](./photos/shots/screenshot2.png)
@@ -16,6 +16,7 @@
 
 - html
 - css
+- javascript
 
 
 To get a local copy up and running follow these simple example steps.

--- a/index.html
+++ b/index.html
@@ -110,12 +110,12 @@
         I’d love to help with it
       </p>
       <div class="form-text">
-        <form id="form" action="https://formspree.io/f/xpzbqzab" method="post">
-          <input class="input" type="text" name="name" id="name" placeholder="Full name" maxlength="30" required />
-          <input class="input" type="email" name="email" id="email" placeholder="Email address" required />
-          <textarea class="msg" name="message" id="message" cols="30" rows="10" placeholder="Write your message here"
+        <form id="form" action="https://formspree.io/f/xpzbqzab" method="post" name="contact-form">
+          <input class="input i-data" type="text" name="fullName" id="name" placeholder="Full name" maxlength="30" required />
+          <input class="input i-data" type="email" name="email" id="email" placeholder="Email address" required />
+          <textarea class="msg i-data" name="comment" id="message" cols="30" rows="10" placeholder="Write your message here"
             maxlength="500" required></textarea>
-            <div id="form-div"></div>
+            <div class="form-mssg" id="form-div"></div>
           <div>
             <button class="about-btn" type="submit">Get In Touch</button>
           </div>

--- a/main.js
+++ b/main.js
@@ -245,7 +245,6 @@ if (formData !== null) {
 }
 formElts.forEach((fe) => {
   fe.addEventListener('input', () => {
-    // errorMessage.style.display = 'none';
     const objectForLocalStorage = {
       name: nameInput.value,
       email: mail.value,

--- a/main.js
+++ b/main.js
@@ -226,7 +226,12 @@ form.addEventListener('submit', (event) => {
 });
 
 // local-storage
-const formElts = form.querySelectorAll('input, textarea');
+const inputFields = document.forms['contact-form']
+const mail = inputFields.email;
+const messageInput = inputFields.comment;
+const nameInput = inputFields.fullName;
+const formElts = inputFields.querySelectorAll('input, textarea');
+
 
 const saveToLocalStorage = (key, data) => localStorage.setItem(key, JSON.stringify(data));
 const getFromLocalStorage = (key) => JSON.parse(localStorage.getItem(key));
@@ -236,10 +241,11 @@ if (formData !== null) {
   nameInput.value = formData.name;
   mail.value = formData.email;
   messageInput.value = formData.message;
+  
 }
 formElts.forEach((fe) => {
   fe.addEventListener('input', () => {
-    errorMessage.style.display = 'none';
+    // errorMessage.style.display = 'none';
     const objectForLocalStorage = {
       name: nameInput.value,
       email: mail.value,

--- a/main.js
+++ b/main.js
@@ -224,3 +224,27 @@ form.addEventListener('submit', (event) => {
   const errorMessage = 'Please enter an email address without any upper-case letters.';
   validateEmail(form.elements.email.value, event, errorMessage);
 });
+
+// local-storage
+const formElts = form.querySelectorAll('input, textarea');
+
+const saveToLocalStorage = (key, data) => localStorage.setItem(key, JSON.stringify(data));
+const getFromLocalStorage = (key) => JSON.parse(localStorage.getItem(key));
+
+const formData = getFromLocalStorage('formData');
+if (formData !== null) {
+  nameInput.value = formData.name;
+  mail.value = formData.email;
+  messageInput.value = formData.message;
+}
+formElts.forEach((fe) => {
+  fe.addEventListener('input', () => {
+    errorMessage.style.display = 'none';
+    const objectForLocalStorage = {
+      name: nameInput.value,
+      email: mail.value,
+      message: messageInput.value,
+    };
+    saveToLocalStorage('formData', objectForLocalStorage);
+  });
+});


### PR DESCRIPTION
## In this milestone, the following were implemented:
- No linter errors.
- Use correct git-flow.
- When the user changes the content of any input field, the data is saved to the local storage.
- When the user loads the page, if there is any data in the local storage the input fields are pre-filled with this data.